### PR TITLE
Update CWS URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
                 <div>A browser addon that highlights transphobic and trans-friendly
                     social network pages and users with different colors.</div>
                 <ul>
-                    <li><a href="https://chrome.google.com/webstore/detail/ijcpiojgefnkmcadacmacogglhjdjphj/">Shinigami
+                    <li><a href="https://chromewebstore.google.com/detail/shinigami-eyes/ijcpiojgefnkmcadacmacogglhjdjphj">Shinigami
                             Eyes for Chrome</a></li>
                     <li><a href="https://addons.mozilla.org/en-US/firefox/addon/shinigami-eyes/">Shinigami Eyes for
                             Firefox</a></li>


### PR DESCRIPTION
The old CWS URL (https://chrome.google.com/webstore/detail/ijcpiojgefnkmcadacmacogglhjdjphj/) no longer works due to the new CWS domain redirect. Replaced with the new one (https://chromewebstore.google.com/detail/shinigami-eyes/ijcpiojgefnkmcadacmacogglhjdjphj) so it'll work again. 